### PR TITLE
fix: exclude empty lrcs

### DIFF
--- a/src/util/parser/parser.ts
+++ b/src/util/parser/parser.ts
@@ -6,27 +6,30 @@ import parseYrc from "./parseYrc";
 import parseYTxml from "./parseYTxml";
 
 export default (lrc: string, showUnformatted = true, source?: Source) => {
-  switch (source) {
-    case Source.Lrc:
-      return parseLrc(lrc, showUnformatted);
-    case Source.Krc:
-      return parseKrc(lrc, showUnformatted);
-    case Source.Qrc:
-      return parseQrc(lrc, showUnformatted);
-    case Source.Yrc:
-      return parseYrc(lrc, showUnformatted);
-    case Source.YTxml:
-      return parseYTxml(lrc, showUnformatted);
-    default:
-      const parsedLrc = [];
-      for (const parser of [parseKrc, parseQrc, parseYrc, parseYTxml]) {
-        const result = parser(lrc, false);
-        if (result.length > 0 && (result[0].karaokeLines?.length ?? 0) > 0)
-          return result;
-        if (result.length > 0) parsedLrc.push(result);
-      }
-      return parsedLrc.length > 0
-        ? parsedLrc[0]
-        : parseLrc(lrc, showUnformatted);
-  }
+  const parse = () => {
+    switch (source) {
+      case Source.Lrc:
+        return parseLrc(lrc, showUnformatted);
+      case Source.Krc:
+        return parseKrc(lrc, showUnformatted);
+      case Source.Qrc:
+        return parseQrc(lrc, showUnformatted);
+      case Source.Yrc:
+        return parseYrc(lrc, showUnformatted);
+      case Source.YTxml:
+        return parseYTxml(lrc, showUnformatted);
+      default:
+        const parsedLrc = [];
+        for (const parser of [parseKrc, parseQrc, parseYrc, parseYTxml]) {
+          const result = parser(lrc, false);
+          if (result.length > 0 && (result[0].karaokeLines?.length ?? 0) > 0)
+            return result;
+          if (result.length > 0) parsedLrc.push(result);
+        }
+        return parsedLrc.length > 0
+          ? parsedLrc[0]
+          : parseLrc(lrc, showUnformatted);
+    }
+  };
+  return parse().filter((v) => v.content.trim() !== "");
 };


### PR DESCRIPTION
seems like android <15/oneUI renders them differently? but its  a better practice doing so